### PR TITLE
Fallback received city names to latin

### DIFF
--- a/flights/location_test.go
+++ b/flights/location_test.go
@@ -152,7 +152,7 @@ func TestAbbrCityLatin(t *testing.T) {
 		t.Fatalf("wrong abbreviated city name, expected: %s received: %s", expectedAbbrCity, abbrCity)
 	}
 
-	abbrCity, err = session.AbbrCity(context.Background(), "Łódź", language.English)
+	abbrCity, err = session.AbbrCity(context.Background(), "łódź", language.English)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/flights/location_test.go
+++ b/flights/location_test.go
@@ -135,3 +135,36 @@ func TestAbbrCity(t *testing.T) {
 		t.Fatalf("Warsaw abbreviated city name not stored in cache")
 	}
 }
+
+func TestAbbrCityLatin(t *testing.T) {
+	session, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedAbbrCity := "/m/0c6fz"
+
+	abbrCity, err := session.AbbrCity(context.Background(), "Łódź", language.English)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abbrCity != expectedAbbrCity {
+		t.Fatalf("wrong abbreviated city name, expected: %s received: %s", expectedAbbrCity, abbrCity)
+	}
+
+	abbrCity, err = session.AbbrCity(context.Background(), "Łódź", language.English)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abbrCity != expectedAbbrCity {
+		t.Fatalf("wrong abbreviated city name, expected: %s received: %s", expectedAbbrCity, abbrCity)
+	}
+
+	abbrCity, err = session.AbbrCity(context.Background(), "lodz", language.English)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abbrCity != expectedAbbrCity {
+		t.Fatalf("wrong abbreviated city name, expected: %s received: %s", expectedAbbrCity, abbrCity)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require golang.org/x/text v0.11.0
 
 require (
+	github.com/anyascii/go v0.3.2
 	github.com/go-test/deep v1.1.0
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	google.golang.org/protobuf v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/anyascii/go v0.3.2 h1:87uFISteh7vwofK02srrPKtAvG6Wx7ozRjNh8uhfa7w=
+github.com/anyascii/go v0.3.2/go.mod h1:HDvbMmSpqJyIe+xtSkHmAYTjc8PzvO3l1Jmgx/IFUPs=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=


### PR DESCRIPTION
This PR enables you to pass latin letters for city names that do not contain only latin letters.
e.g.:
All the following AbbrCity calls will successfully receive the abbreviated "Łódź" city name.
```
session.AbbrCity(context.Background(), "Łódź", language.English)
session.AbbrCity(context.Background(), "łódź", language.English)
session.AbbrCity(context.Background(), "lodz", language.English)
```
