### PR TITLE
Unify arguments and enable search offers for different Travelers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The call below uses Spanish city names:
 ```
 offers, priceRange, err := session.GetOffers(
     context.Background(),
-    flights.OffersArgs{
+    flights.Args{
         Date:       time.Now().AddDate(0, 0, 30),
         ReturnDate: time.Now().AddDate(0, 0, 37),
         SrcCities:  []string{"Madrid"},

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ offers, err := session.GetPriceGraph(
         TripLength:     7,
         SrcCities:      []string{"San Francisco"},
         DstCities:      []string{"New York"},
-        Args:           flights.ArgsDefault(),
+        Options:        flights.OptionsDefault(),
     },
 )
 if err != nil {
@@ -54,13 +54,13 @@ Example output:
 ```
 url, err := session.SerializeURL(
     context.Background(),
-    flights.URLArgs{
+    flights.Args{
         Date:        time.Now().AddDate(0, 0, 30),
         ReturnDate:  time.Now().AddDate(0, 0, 37),
         SrcCities:   []string{"San Diego"},
         SrcAirports: []string{"LAX"},
         DstCities:   []string{"New York", "Philadelphia"},
-        Args:        flights.ArgsDefault(),
+        Options:     flights.OptionsDefault(),
     },
 )
 if err != nil {
@@ -83,7 +83,7 @@ offers, priceRange, err := session.GetOffers(
         ReturnDate: time.Now().AddDate(0, 0, 37),
         SrcCities:  []string{"Madrid"},
         DstCities:  []string{"Estocolmo"},
-        Args: flights.Args{
+        Options:    flights.Options{
             Travelers: flights.Travelers{Adults: 2},
             Currency:  currency.EUR,
             Stops:     flights.Stop1,

--- a/examples/example1/main.go
+++ b/examples/example1/main.go
@@ -23,7 +23,7 @@ func getCheapesOffer(
 		log.Fatal(err)
 	}
 
-	args := flights.Args{
+	options := flights.Options{
 		Travelers: flights.Travelers{Adults: 1},
 		Currency:  currency.PLN,
 		Stops:     flights.AnyStops,
@@ -40,7 +40,7 @@ func getCheapesOffer(
 			TripLength:     tripLength,
 			SrcCities:      []string{srcCity},
 			DstCities:      []string{dstCity},
-			Args:           args,
+			Options:        options,
 		},
 	)
 	if err != nil {
@@ -58,12 +58,12 @@ func getCheapesOffer(
 	fmt.Printf("price %d\n", int(bestOffer.Price))
 	url, err := session.SerializeURL(
 		context.Background(),
-		flights.URLArgs{
+		flights.Args{
 			Date:       bestOffer.StartDate,
 			ReturnDate: bestOffer.ReturnDate,
 			SrcCities:  []string{srcCity},
 			DstCities:  []string{dstCity},
-			Args:       args,
+			Options:    options,
 		},
 	)
 	if err != nil {

--- a/examples/example2/main.go
+++ b/examples/example2/main.go
@@ -23,7 +23,7 @@ func getCheapOffers(
 ) {
 	logger := log.New(os.Stdout, "", 0)
 
-	args := flights.Options{
+	options := flights.Options{
 		Travelers: flights.Travelers{Adults: 1},
 		Currency:  currency.USD,
 		Stops:     flights.AnyStops,
@@ -40,7 +40,7 @@ func getCheapOffers(
 			TripLength:     tripLength,
 			SrcCities:      srcCities,
 			DstCities:      dstCities,
-			Options:        args,
+			Options:        options,
 		},
 	)
 	if err != nil {
@@ -55,7 +55,7 @@ func getCheapOffers(
 				ReturnDate: priceGraphOffer.ReturnDate,
 				SrcCities:  srcCities,
 				DstCities:  dstCities,
-				Options:    args,
+				Options:    options,
 			},
 		)
 		if err != nil {
@@ -76,7 +76,7 @@ func getCheapOffers(
 				ReturnDate:  bestOffer.ReturnDate,
 				SrcAirports: []string{bestOffer.SrcAirportCode},
 				DstAirports: []string{bestOffer.DstAirportCode},
-				Options:     args,
+				Options:     options,
 			},
 		)
 		if err != nil {
@@ -94,7 +94,7 @@ func getCheapOffers(
 					ReturnDate:  bestOffer.ReturnDate,
 					SrcAirports: []string{bestOffer.SrcAirportCode},
 					DstAirports: []string{bestOffer.DstAirportCode},
-					Options:     args,
+					Options:     options,
 				},
 			)
 			if err != nil {

--- a/examples/example2/main.go
+++ b/examples/example2/main.go
@@ -23,7 +23,7 @@ func getCheapOffers(
 ) {
 	logger := log.New(os.Stdout, "", 0)
 
-	args := flights.Args{
+	args := flights.Options{
 		Travelers: flights.Travelers{Adults: 1},
 		Currency:  currency.USD,
 		Stops:     flights.AnyStops,
@@ -40,7 +40,7 @@ func getCheapOffers(
 			TripLength:     tripLength,
 			SrcCities:      srcCities,
 			DstCities:      dstCities,
-			Args:           args,
+			Options:        args,
 		},
 	)
 	if err != nil {
@@ -50,12 +50,12 @@ func getCheapOffers(
 	for _, priceGraphOffer := range priceGraphOffers {
 		offers, _, err := session.GetOffers(
 			context.Background(),
-			flights.OffersArgs{
+			flights.Args{
 				Date:       priceGraphOffer.StartDate,
 				ReturnDate: priceGraphOffer.ReturnDate,
 				SrcCities:  srcCities,
 				DstCities:  dstCities,
-				Args:       args,
+				Options:    args,
 			},
 		)
 		if err != nil {
@@ -71,12 +71,12 @@ func getCheapOffers(
 
 		_, priceRange, err := session.GetOffers(
 			context.Background(),
-			flights.OffersArgs{
+			flights.Args{
 				Date:        bestOffer.StartDate,
 				ReturnDate:  bestOffer.ReturnDate,
 				SrcAirports: []string{bestOffer.SrcAirportCode},
 				DstAirports: []string{bestOffer.DstAirportCode},
-				Args:        args,
+				Options:     args,
 			},
 		)
 		if err != nil {
@@ -89,12 +89,12 @@ func getCheapOffers(
 		if bestOffer.Price < priceRange.Low {
 			url, err := session.SerializeURL(
 				context.Background(),
-				flights.URLArgs{
+				flights.Args{
 					Date:        bestOffer.StartDate,
 					ReturnDate:  bestOffer.ReturnDate,
 					SrcAirports: []string{bestOffer.SrcAirportCode},
 					DstAirports: []string{bestOffer.DstAirportCode},
-					Args:        args,
+					Options:     args,
 				},
 			)
 			if err != nil {

--- a/examples/example3/main.go
+++ b/examples/example3/main.go
@@ -25,7 +25,7 @@ func getCheapOffersConcurrent(
 ) {
 	logger := log.New(os.Stdout, "", 0)
 
-	args := flights.Args{
+	options := flights.Options{
 		Travelers: flights.Travelers{Adults: 1},
 		Currency:  currency.USD,
 		Stops:     flights.AnyStops,
@@ -42,7 +42,7 @@ func getCheapOffersConcurrent(
 			TripLength:     tripLength,
 			SrcCities:      srcCities,
 			DstCities:      dstCities,
-			Args:           args,
+			Options:        options,
 		},
 	)
 	if err != nil {
@@ -59,12 +59,12 @@ func getCheapOffersConcurrent(
 			defer wg.Done()
 			offers, _, err := session.GetOffers(
 				context.Background(),
-				flights.OffersArgs{
+				flights.Args{
 					Date:       offer.StartDate,
 					ReturnDate: offer.ReturnDate,
 					SrcCities:  srcCities,
 					DstCities:  dstCities,
-					Args:       args,
+					Options:    options,
 				},
 			)
 			if err != nil {
@@ -80,12 +80,12 @@ func getCheapOffersConcurrent(
 
 			_, priceRange, err := session.GetOffers(
 				context.Background(),
-				flights.OffersArgs{
+				flights.Args{
 					Date:        bestOffer.StartDate,
 					ReturnDate:  bestOffer.ReturnDate,
 					SrcAirports: []string{bestOffer.SrcAirportCode},
 					DstAirports: []string{bestOffer.DstAirportCode},
-					Args:        args,
+					Options:     options,
 				},
 			)
 			if err != nil {
@@ -98,12 +98,12 @@ func getCheapOffersConcurrent(
 			if bestOffer.Price < priceRange.Low {
 				url, err := session.SerializeURL(
 					context.Background(),
-					flights.URLArgs{
+					flights.Args{
 						Date:        bestOffer.StartDate,
 						ReturnDate:  bestOffer.ReturnDate,
 						SrcAirports: []string{bestOffer.SrcAirportCode},
 						DstAirports: []string{bestOffer.DstAirportCode},
-						Args:        args,
+						Options:     options,
 					},
 				)
 				if err != nil {

--- a/flights/examples_test.go
+++ b/flights/examples_test.go
@@ -25,7 +25,7 @@ func ExampleSession_GetPriceGraph() {
 			TripLength:     7,
 			SrcCities:      []string{"San Francisco"},
 			DstCities:      []string{"New York"},
-			Options:        flights.ArgsDefault(),
+			Options:        flights.OptionsDefault(),
 		},
 	)
 	if err != nil {
@@ -48,7 +48,7 @@ func ExampleSession_SerializeURL() {
 			SrcCities:   []string{"San Diego"},
 			SrcAirports: []string{"LAX"},
 			DstCities:   []string{"New York", "Philadelphia"},
-			Options:     flights.ArgsDefault(),
+			Options:     flights.OptionsDefault(),
 		},
 	)
 	if err != nil {

--- a/flights/examples_test.go
+++ b/flights/examples_test.go
@@ -25,7 +25,7 @@ func ExampleSession_GetPriceGraph() {
 			TripLength:     7,
 			SrcCities:      []string{"San Francisco"},
 			DstCities:      []string{"New York"},
-			Args:           flights.ArgsDefault(),
+			Options:        flights.ArgsDefault(),
 		},
 	)
 	if err != nil {
@@ -42,13 +42,13 @@ func ExampleSession_SerializeURL() {
 
 	url, err := session.SerializeURL(
 		context.Background(),
-		flights.URLArgs{
+		flights.Args{
 			Date:        time.Now().AddDate(0, 0, 30),
 			ReturnDate:  time.Now().AddDate(0, 0, 37),
 			SrcCities:   []string{"San Diego"},
 			SrcAirports: []string{"LAX"},
 			DstCities:   []string{"New York", "Philadelphia"},
-			Args:        flights.ArgsDefault(),
+			Options:     flights.ArgsDefault(),
 		},
 	)
 	if err != nil {
@@ -65,12 +65,12 @@ func ExampleSession_GetOffers() {
 
 	offers, priceRange, err := session.GetOffers(
 		context.Background(),
-		flights.OffersArgs{
+		flights.Args{
 			Date:       time.Now().AddDate(0, 0, 30),
 			ReturnDate: time.Now().AddDate(0, 0, 37),
 			SrcCities:  []string{"Madrid"},
 			DstCities:  []string{"Estocolmo"},
-			Args: flights.Args{
+			Options: flights.Options{
 				Travelers: flights.Travelers{Adults: 2},
 				Currency:  currency.EUR,
 				Stops:     flights.Stop1,

--- a/flights/price_graph.go
+++ b/flights/price_graph.go
@@ -15,18 +15,7 @@ import (
 )
 
 func (s *Session) getPriceGraphRawData(ctx context.Context, args PriceGraphArgs) (string, error) {
-	return s.getRawData(
-		ctx,
-		OffersArgs{
-			Date:        args.RangeStartDate,
-			ReturnDate:  args.RangeStartDate.AddDate(0, 0, args.TripLength),
-			SrcCities:   args.SrcCities,
-			SrcAirports: args.SrcAirports,
-			DstCities:   args.DstCities,
-			DstAirports: args.DstAirports,
-			Args:        args.Args,
-		},
-	)
+	return s.getRawData(ctx, args.Convert())
 }
 
 func (s *Session) getPriceGraphReqData(ctx context.Context, args PriceGraphArgs) (string, error) {
@@ -144,6 +133,9 @@ func (s *Session) GetPriceGraph(ctx context.Context, args PriceGraphArgs) ([]Off
 		readLine(body) // skip line
 		bytesToDecode, err := getInnerBytes(body)
 		if err != nil {
+			sortSlice(offers, func(lv, rv Offer) bool {
+				return lv.StartDate.Before(rv.StartDate)
+			})
 			return offers, nil
 		}
 

--- a/flights/price_graph_test.go
+++ b/flights/price_graph_test.go
@@ -49,9 +49,6 @@ func testGetPriceGraphTravelers(t *testing.T, session *Session, rootPrice float6
 	if len(offers) < 1 {
 		t.Fatalf("not enough offers (%d) for the following Travelers: %+v", len(offers), args.Travelers)
 	}
-	// fmt.Println(offers[0].StartDate)
-	// fmt.Println(offers[0].ReturnDate)
-	// fmt.Println(offers[0].Price)
 	if !compareWithThreshold(rootPrice*multiplier, offers[0].Price) {
 		t.Fatalf("The received price should be %d times larger than the root price: %f, %f", int(multiplier), rootPrice, offers[0].Price)
 	}

--- a/flights/price_graph_test.go
+++ b/flights/price_graph_test.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-func TestGetPriceGraphReal(t *testing.T) {
+func TestGetPriceGraph(t *testing.T) {
 	session, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -29,11 +29,10 @@ func TestGetPriceGraphReal(t *testing.T) {
 			time.Now().AddDate(0, 0, daysDiff2),
 			7,
 			[]string{"London"}, []string{}, []string{"Paris"}, []string{},
-			Args{Travelers{Adults: 1}, currency.PLN, AnyStops, Economy, RoundTrip, language.English},
+			Options{Travelers{Adults: 1}, currency.PLN, AnyStops, Economy, RoundTrip, language.English},
 		})
-
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
 	if len(offers) != expectedOffers {
@@ -42,7 +41,58 @@ func TestGetPriceGraphReal(t *testing.T) {
 	}
 }
 
-func TestGetPriceGraph(t *testing.T) {
+func testGetPriceGraphTravelers(t *testing.T, session *Session, rootPrice float64, args PriceGraphArgs, multiplier float64) {
+	offers, err := session.GetPriceGraph(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(offers) < 1 {
+		t.Fatalf("not enough offers (%d) for the following Travelers: %+v", len(offers), args.Travelers)
+	}
+	// fmt.Println(offers[0].StartDate)
+	// fmt.Println(offers[0].ReturnDate)
+	// fmt.Println(offers[0].Price)
+	if !compareWithThreshold(rootPrice*multiplier, offers[0].Price) {
+		t.Fatalf("The received price should be %d times larger than the root price: %f, %f", int(multiplier), rootPrice, offers[0].Price)
+	}
+}
+
+func TestGetPriceGraphTravelers(t *testing.T) {
+	session, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args := PriceGraphArgs{
+		time.Now().AddDate(0, 0, 60),
+		time.Now().AddDate(0, 0, 90),
+		7,
+		[]string{"London"}, []string{}, []string{"Paris"}, []string{},
+		Options{Travelers{Adults: 1}, currency.PLN, AnyStops, Economy, RoundTrip, language.English},
+	}
+
+	offers, err := session.GetPriceGraph(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(offers) < 1 {
+		t.Fatalf("not enough offers: %d", len(offers))
+	}
+
+	rootPrice := offers[0].Price
+
+	args.Travelers = Travelers{Adults: 2}
+	testGetPriceGraphTravelers(t, session, rootPrice, args, 2)
+
+	args.Travelers = Travelers{Adults: 2, Children: 1}
+	testGetPriceGraphTravelers(t, session, rootPrice, args, 3)
+
+	args.Travelers = Travelers{Adults: 2, Children: 1, InfantInSeat: 1}
+	testGetPriceGraphTravelers(t, session, rootPrice, args, 4)
+}
+
+func TestGetPriceGraphMock(t *testing.T) {
 	expectedPrices := []float64{
 		922, 562, 648, 654, 660, 714, 891, 594, 594, 539, 648, 715, 654, 654, 594,
 		594, 594, 680, 743, 654, 699, 654, 594, 594, 654, 654, 654, 806, 755, 617,
@@ -66,6 +116,9 @@ func TestGetPriceGraph(t *testing.T) {
 		"testdata/city_warsaw.resp",
 		"testdata/price_graph.resp",
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	session := &Session{
 		client: httpClientMock,
@@ -78,16 +131,12 @@ func TestGetPriceGraph(t *testing.T) {
 			time.Now().AddDate(0, 0, 5),
 			0,
 			[]string{"Athens"}, []string{}, []string{"Warsaw"}, []string{},
-			Args{Travelers{}, currency.PLN, AnyStops, Economy, RoundTrip, language.English},
+			Options{Travelers{}, currency.PLN, AnyStops, Economy, RoundTrip, language.English},
 		},
 	)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-
-	sortSlice(offers, func(lv, rv Offer) bool {
-		return lv.StartDate.Before(rv.StartDate)
-	})
 
 	if len(expectedPrices) != len(offers) {
 		t.Fatalf("wrong offers length, expected: %d, received: %d", len(expectedPrices), len(offers))
@@ -125,7 +174,7 @@ func TestPriceGraphReqData(t *testing.T) {
 			[]string{"SFO"},
 			[]string{"London"},
 			[]string{"CDG"},
-			Args{Travelers{Adults: 1}, currency.USD, AnyStops, Economy, RoundTrip, language.English},
+			Options{Travelers{Adults: 1}, currency.USD, AnyStops, Economy, RoundTrip, language.English},
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +199,7 @@ func TestPriceGraphReqData(t *testing.T) {
 			[]string{"SFO"},
 			[]string{"London"},
 			[]string{"CDG"},
-			Args{Travelers{Adults: 2}, currency.USD, Stop2, Business, OneWay, language.English},
+			Options{Travelers{Adults: 2}, currency.USD, Stop2, Business, OneWay, language.English},
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/flights/types.go
+++ b/flights/types.go
@@ -222,7 +222,7 @@ type Options struct {
 	Lang      language.Tag // language in which city names are provided
 }
 
-func ArgsDefault() Options {
+func OptionsDefault() Options {
 	return Options{
 		Travelers: Travelers{Adults: 1},
 		Currency:  currency.USD,

--- a/flights/types.go
+++ b/flights/types.go
@@ -212,7 +212,7 @@ func validateLocations(srcCities, srcAirports, dstCities, dstAirports []string) 
 	return nil
 }
 
-// Options contains common arguments used in [OffersArgs], [PriceGraphArgs] and [URLArgs].
+// Options contains common arguments used in [Args] and [PriceGraphArgs].
 type Options struct {
 	Travelers Travelers
 	Currency  currency.Unit

--- a/flights/types.go
+++ b/flights/types.go
@@ -31,8 +31,10 @@ func (f Flight) String() string {
 	out := ""
 	out += fmt.Sprintf("DepAirportCode: %s ", f.DepAirportCode)
 	out += fmt.Sprintf("DepAirportName: %s ", f.DepAirportName)
+	out += fmt.Sprintf("DepCity: %s ", f.DepCity)
 	out += fmt.Sprintf("ArrAirportName: %s ", f.ArrAirportName)
 	out += fmt.Sprintf("ArrAirportCode: %s ", f.ArrAirportCode)
+	out += fmt.Sprintf("ArrCity: %s ", f.ArrCity)
 	out += fmt.Sprintf("DepTime: %s ", f.DepTime)
 	out += fmt.Sprintf("ArrTime: %s ", f.ArrTime)
 	out += fmt.Sprintf("Duration: %s ", f.Duration)
@@ -69,8 +71,8 @@ type FullOffer struct {
 	ReturnFlight         []Flight      // not implemented yet
 	SrcAirportCode       string        // code of the airport where the trip starts
 	DstAirportCode       string        // destination airport
-	SrcCity              string        // not implemented yet
-	DstCity              string        // not implemented yet
+	SrcCity              string        // source city
+	DstCity              string        // destination city
 	FlightDuration       time.Duration // duration of whole Flight
 	ReturnFlightDuration time.Duration // not implemented yet
 }
@@ -84,8 +86,8 @@ func (o FullOffer) String() string {
 	// out += fmt.Sprintf("ReturnFlight: %s\n", o.ReturnFlight)
 	out += fmt.Sprintf("SrcAirportCode: %s\n", o.SrcAirportCode)
 	out += fmt.Sprintf("DstAirportCode: %s\n", o.DstAirportCode)
-	// out += fmt.Sprintf("SrcCity: %s\n", o.SrcCity)
-	// out += fmt.Sprintf("DstCity: %s\n", o.DstCity)
+	out += fmt.Sprintf("SrcCity: %s\n", o.SrcCity)
+	out += fmt.Sprintf("DstCity: %s\n", o.DstCity)
 	out += fmt.Sprintf("FlightDuration: %s}\n", o.FlightDuration)
 	// out += fmt.Sprintf("ReturnFlightDuration: %s}\n", o.ReturnFlightDuration)
 	return out
@@ -210,8 +212,8 @@ func validateLocations(srcCities, srcAirports, dstCities, dstAirports []string) 
 	return nil
 }
 
-// Args contains common arguments used in [OffersArgs], [PriceGraphArgs] and [URLArgs].
-type Args struct {
+// Options contains common arguments used in [OffersArgs], [PriceGraphArgs] and [URLArgs].
+type Options struct {
 	Travelers Travelers
 	Currency  currency.Unit
 	Stops     Stops        // maximum number of stops
@@ -220,8 +222,8 @@ type Args struct {
 	Lang      language.Tag // language in which city names are provided
 }
 
-func ArgsDefault() Args {
-	return Args{
+func ArgsDefault() Options {
+	return Options{
 		Travelers: Travelers{Adults: 1},
 		Currency:  currency.USD,
 		Stops:     AnyStops,
@@ -236,7 +238,7 @@ type PriceGraphArgs struct {
 	RangeStartDate, RangeEndDate                   time.Time // days range of the price graph
 	TripLength                                     int       // number of days between start trip date and return date
 	SrcCities, SrcAirports, DstCities, DstAirports []string  // source and destination; cities and airports of the trip
-	Args
+	Options                                                  // additional options
 }
 
 // Validates PriceGraphArgs requirements:
@@ -260,19 +262,32 @@ func (a *PriceGraphArgs) Validate() error {
 	return nil
 }
 
-// Arguments used in [Session.GetOffers].
-type OffersArgs struct {
-	Date, ReturnDate                               time.Time // start trip date and return date
-	SrcCities, SrcAirports, DstCities, DstAirports []string  // source and destination; cities and airports of the trip
-	Args
+// Converts PriceGraphArgs to [Args]. It sets the date range to 30 days.
+func (a *PriceGraphArgs) Convert() Args {
+	return Args{
+		Date:        a.RangeStartDate,
+		ReturnDate:  a.RangeStartDate.AddDate(0, 0, a.TripLength),
+		SrcCities:   a.SrcCities,
+		SrcAirports: a.SrcAirports,
+		DstCities:   a.DstCities,
+		DstAirports: a.DstAirports,
+		Options:     a.Options,
+	}
 }
 
-// Validates OffersArgs requirements:
+// Arguments used in [Session.GetOffers] and [Session.SerializeURL].
+type Args struct {
+	Date, ReturnDate                               time.Time // start trip date and return date
+	SrcCities, SrcAirports, DstCities, DstAirports []string  // source and destination; cities and airports of the trip
+	Options                                                  // additional options
+}
+
+// Validates Offers arguments requirements:
 //   - at least one source location (srcCities / srcAirports)
 //   - at least one destination location (dstCities / dstAirports)
 //   - srcAirports and dstAirports have to be in the right IATA format: https://en.wikipedia.org/wiki/IATA_airport_code
 //   - dates have to be in chronological order: today's date -> Date -> ReturnDate
-func (a *OffersArgs) Validate() error {
+func (a *Args) ValidateOffersArgs() error {
 	if err := validateLocations(a.SrcCities, a.SrcAirports, a.DstCities, a.DstAirports); err != nil {
 		return err
 	}
@@ -287,17 +302,24 @@ func (a *OffersArgs) Validate() error {
 	return nil
 }
 
-// Arguments used in [Session.SerializeURL].
-type URLArgs struct {
-	Date, ReturnDate                               time.Time // start trip date and retrun date
-	SrcCities, SrcAirports, DstCities, DstAirports []string  // source and destination; cities and airports of the trip
-	Args
-}
-
-// Validates URLArgs requirements:
+// Validates URL arguments requirements:
 //   - at least one source location (srcCities / srcAirports)
 //   - at least one destination location (dstCities / dstAirports)
 //   - srcAirports and dstAirports have to be in the right IATA format: https://en.wikipedia.org/wiki/IATA_airport_code
-func (a *URLArgs) Validate() error {
+func (a *Args) ValidateURLArgs() error {
 	return validateLocations(a.SrcCities, a.SrcAirports, a.DstCities, a.DstAirports)
+}
+
+// Converts Args to [PriceGraphArgs]. It sets the date range to 30 days.
+func (a *Args) Convert() PriceGraphArgs {
+	return PriceGraphArgs{
+		RangeStartDate: a.ReturnDate,
+		RangeEndDate:   a.ReturnDate.AddDate(0, 0, 30),
+		TripLength:     int(a.ReturnDate.Sub(a.Date).Hours() / 24),
+		SrcCities:      a.SrcCities,
+		SrcAirports:    a.SrcAirports,
+		DstCities:      a.DstCities,
+		DstAirports:    a.DstAirports,
+		Options:        a.Options,
+	}
 }

--- a/flights/types_test.go
+++ b/flights/types_test.go
@@ -7,11 +7,17 @@ import (
 
 const wrongAirportCode = "wrong"
 
-type validatable interface {
-	Validate() error
+func _testValidateOffersArgs(t *testing.T, args Args, errorValue string) {
+	err := args.ValidateOffersArgs()
+
+	if err == nil {
+		t.Fatalf("validate call, should result in error")
+	} else if err.Error() != errorValue {
+		t.Fatalf(`Wrong error "%s"`, errorValue)
+	}
 }
 
-func _testValidate(t *testing.T, args validatable, errorValue string) {
+func _testValidatePriceGraphArgs(t *testing.T, args PriceGraphArgs, errorValue string) {
 	err := args.Validate()
 
 	if err == nil {
@@ -21,86 +27,96 @@ func _testValidate(t *testing.T, args validatable, errorValue string) {
 	}
 }
 
+func _testValidateURLArg(t *testing.T, args Args, errorValue string) {
+	err := args.ValidateURLArgs()
+
+	if err == nil {
+		t.Fatalf("validate call, should result in error")
+	} else if err.Error() != errorValue {
+		t.Fatalf(`Wrong error "%s"`, errorValue)
+	}
+}
+
 func TestValidateOffersArgs(t *testing.T) {
-	args := OffersArgs{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{}, DstAirports: []string{}}
-	_testValidate(t, &args, "dst locations: number of locations should be at least 1, specified: 0")
+	args := Args{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{}, DstAirports: []string{}}
+	_testValidateOffersArgs(t, args, "dst locations: number of locations should be at least 1, specified: 0")
 
-	args = OffersArgs{SrcCities: []string{}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{}}
-	_testValidate(t, &args, "src locations: number of locations should be at least 1, specified: 0")
+	args = Args{SrcCities: []string{}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{}}
+	_testValidateOffersArgs(t, args, "src locations: number of locations should be at least 1, specified: 0")
 
-	args = OffersArgs{SrcCities: []string{"abc"}, SrcAirports: []string{wrongAirportCode}, DstCities: []string{"abc"}, DstAirports: []string{}}
-	_testValidate(t, &args, "src airport 'wrong' is not an airport code")
+	args = Args{SrcCities: []string{"abc"}, SrcAirports: []string{wrongAirportCode}, DstCities: []string{"abc"}, DstAirports: []string{}}
+	_testValidateOffersArgs(t, args, "src airport 'wrong' is not an airport code")
 
-	args = OffersArgs{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{wrongAirportCode}}
-	_testValidate(t, &args, "dst airport 'wrong' is not an airport code")
+	args = Args{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{wrongAirportCode}}
+	_testValidateOffersArgs(t, args, "dst airport 'wrong' is not an airport code")
 
-	args = OffersArgs{
+	args = Args{
 		SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{},
 		Date:       time.Now().AddDate(0, 0, 3),
 		ReturnDate: time.Now().AddDate(0, 0, 1),
 	}
-	_testValidate(t, &args, "returnDate is before date")
+	_testValidateOffersArgs(t, args, "returnDate is before date")
 
-	args = OffersArgs{
+	args = Args{
 		SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{},
 		Date:       time.Now().AddDate(0, 0, -1),
 		ReturnDate: time.Now().AddDate(0, 0, 1),
 	}
-	_testValidate(t, &args, "date is before today's date")
+	_testValidateOffersArgs(t, args, "date is before today's date")
 }
 
 func TestValidatePriceGraphArgs(t *testing.T) {
 	args := PriceGraphArgs{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{}, DstAirports: []string{}}
-	_testValidate(t, &args, "dst locations: number of locations should be at least 1, specified: 0")
+	_testValidatePriceGraphArgs(t, args, "dst locations: number of locations should be at least 1, specified: 0")
 
 	args = PriceGraphArgs{SrcCities: []string{}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{}}
-	_testValidate(t, &args, "src locations: number of locations should be at least 1, specified: 0")
+	_testValidatePriceGraphArgs(t, args, "src locations: number of locations should be at least 1, specified: 0")
 
 	args = PriceGraphArgs{SrcCities: []string{"abc"}, SrcAirports: []string{wrongAirportCode}, DstCities: []string{"abc"}, DstAirports: []string{}}
-	_testValidate(t, &args, "src airport 'wrong' is not an airport code")
+	_testValidatePriceGraphArgs(t, args, "src airport 'wrong' is not an airport code")
 
 	args = PriceGraphArgs{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{wrongAirportCode}}
-	_testValidate(t, &args, "dst airport 'wrong' is not an airport code")
+	_testValidatePriceGraphArgs(t, args, "dst airport 'wrong' is not an airport code")
 
 	args = PriceGraphArgs{
 		SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{},
 		RangeStartDate: time.Now().AddDate(0, 0, 5),
 		RangeEndDate:   time.Now().AddDate(0, 0, 170),
 	}
-	_testValidate(t, &args, "number of days between dates is larger than 161, 165")
+	_testValidatePriceGraphArgs(t, args, "number of days between dates is larger than 161, 165")
 
 	args = PriceGraphArgs{
 		SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{},
 		RangeStartDate: time.Now().AddDate(0, 0, 2),
 		RangeEndDate:   time.Now().AddDate(0, 0, 2),
 	}
-	_testValidate(t, &args, "rangeEndDate is the same as rangeStartDate")
+	_testValidatePriceGraphArgs(t, args, "rangeEndDate is the same as rangeStartDate")
 
 	args = PriceGraphArgs{
 		SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{},
 		RangeStartDate: time.Now().AddDate(0, 0, 5),
 		RangeEndDate:   time.Now().AddDate(0, 0, 2),
 	}
-	_testValidate(t, &args, "rangeEndDate is before rangeStartDate")
+	_testValidatePriceGraphArgs(t, args, "rangeEndDate is before rangeStartDate")
 
 	args = PriceGraphArgs{
 		SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{},
 		RangeStartDate: time.Now().AddDate(0, 0, -1),
 		RangeEndDate:   time.Now().AddDate(0, 0, 2),
 	}
-	_testValidate(t, &args, "rangeStartDate is before today's date")
+	_testValidatePriceGraphArgs(t, args, "rangeStartDate is before today's date")
 }
 
 func TestValidateURLArgs(t *testing.T) {
-	args := URLArgs{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{}, DstAirports: []string{}}
-	_testValidate(t, &args, "dst locations: number of locations should be at least 1, specified: 0")
+	args := Args{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{}, DstAirports: []string{}}
+	_testValidateURLArg(t, args, "dst locations: number of locations should be at least 1, specified: 0")
 
-	args = URLArgs{SrcCities: []string{}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{}}
-	_testValidate(t, &args, "src locations: number of locations should be at least 1, specified: 0")
+	args = Args{SrcCities: []string{}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{}}
+	_testValidateURLArg(t, args, "src locations: number of locations should be at least 1, specified: 0")
 
-	args = URLArgs{SrcCities: []string{"abc"}, SrcAirports: []string{wrongAirportCode}, DstCities: []string{"abc"}, DstAirports: []string{}}
-	_testValidate(t, &args, "src airport 'wrong' is not an airport code")
+	args = Args{SrcCities: []string{"abc"}, SrcAirports: []string{wrongAirportCode}, DstCities: []string{"abc"}, DstAirports: []string{}}
+	_testValidateURLArg(t, args, "src airport 'wrong' is not an airport code")
 
-	args = URLArgs{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{wrongAirportCode}}
-	_testValidate(t, &args, "dst airport 'wrong' is not an airport code")
+	args = Args{SrcCities: []string{"abc"}, SrcAirports: []string{}, DstCities: []string{"abc"}, DstAirports: []string{wrongAirportCode}}
+	_testValidateURLArg(t, args, "dst airport 'wrong' is not an airport code")
 }

--- a/flights/url.go
+++ b/flights/url.go
@@ -35,7 +35,7 @@ func serializeFlight(
 	}
 }
 
-func serializeFlights(args URLArgs) []*urlpb.Url_Flight {
+func serializeFlights(args Args) []*urlpb.Url_Flight {
 	if args.TripType == OneWay {
 		return []*urlpb.Url_Flight{
 			serializeFlight(args.Date, args.SrcCities, args.SrcAirports, args.DstCities, args.DstAirports, args.Stops),
@@ -73,11 +73,11 @@ func serializeTravelers(travelers Travelers) []urlpb.Url_Traveler {
 //
 // GetPriceGraph returns an error if any of the requests fail or if any of the city names are misspelled.
 //
-// Requirements are described by the [URLArgs.Validate] function.
-func (s *Session) SerializeURL(ctx context.Context, args URLArgs) (string, error) {
+// Requirements are described by the [Args.ValidateURLArgs] function.
+func (s *Session) SerializeURL(ctx context.Context, args Args) (string, error) {
 	var err error
 
-	if err = args.Validate(); err != nil {
+	if err = args.ValidateURLArgs(); err != nil {
 		return "", err
 	}
 

--- a/flights/url_test.go
+++ b/flights/url_test.go
@@ -22,14 +22,14 @@ func TestSerializeURL1(t *testing.T) {
 
 	url, err := session.SerializeURL(
 		context.Background(),
-		URLArgs{
+		Args{
 			date,
 			returnDate,
 			[]string{"Los Angeles"},
 			[]string{"SFO"},
 			[]string{"London"},
 			[]string{"CDG"},
-			Args{Travelers{Adults: 1}, currency.USD, Stop1, Economy, RoundTrip, language.English},
+			Options{Travelers{Adults: 1}, currency.USD, Stop1, Economy, RoundTrip, language.English},
 		},
 	)
 
@@ -55,14 +55,14 @@ func TestSerializeURL2(t *testing.T) {
 
 	url, err := session.SerializeURL(
 		context.Background(),
-		URLArgs{
+		Args{
 			date,
 			returnDate,
 			[]string{"London"},
 			[]string{"SFO"},
 			[]string{"Miami"},
 			[]string{},
-			Args{Travelers{Adults: 2, Children: 1, InfantOnLap: 1}, currency.USD, Stop2, Economy, RoundTrip, language.English},
+			Options{Travelers{Adults: 2, Children: 1, InfantOnLap: 1}, currency.USD, Stop2, Economy, RoundTrip, language.English},
 		},
 	)
 

--- a/iata/generate/generate.go
+++ b/iata/generate/generate.go
@@ -83,7 +83,7 @@ func main() {
 		go func(iata, tz, city string) {
 			defer wg.Done()
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
 			defer cancel()
 
 			ok, err := session.IsIATASupported(ctx, iata)


### PR DESCRIPTION
This PR:
- unifies OffersArgs and URLArgs to Args
- adds functions to convert between arguments
- adds the ability to search offers with children and infants